### PR TITLE
Example using module binaries

### DIFF
--- a/bin/mini_process.py
+++ b/bin/mini_process.py
@@ -1,4 +1,0 @@
-#!/usr/bin/env python3
-
-print("world")
-print("change in script to test resume")

--- a/main.nf
+++ b/main.nf
@@ -1,20 +1,8 @@
 #!/usr/bin/env nextflow
+nextflow.enable.moduleBinaries = true
 
-nextflow.enable.dsl=2
-
-process hello {
-    script:
-    """
-    echo "Hello"
-    """
-}
-
-process world {
-    script:
-    """
-    mini_process.py
-    """ 
-}
+include { hello } from './modules/hello'
+include { world } from './modules/world'
 
 workflow {
     hello()

--- a/modules/hello/main.nf
+++ b/modules/hello/main.nf
@@ -1,0 +1,6 @@
+process hello {
+    script:
+    """
+    echo "Hello"
+    """
+}

--- a/modules/world/main.nf
+++ b/modules/world/main.nf
@@ -1,0 +1,7 @@
+process world {
+    script:
+    """
+    mini_process.py
+    """ 
+}
+

--- a/modules/world/resources/bin/mini_process.py
+++ b/modules/world/resources/bin/mini_process.py
@@ -1,0 +1,4 @@
+#!/usr/bin/env python3
+
+print("world")
+print("change in script to test resume!")


### PR DESCRIPTION
This is an example of how to pull out accessory scripts into module binaries.

In this way, a single accessory executable can be identified to belong to a specific module, rather than being loaded into the $PATH for all tasks/processes.